### PR TITLE
Add CI workflows, Docker build, external-consumer probe, and AGENTS.md documentation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.build/
+.swiftpm/
+.git/
+.DS_Store
+**/.build/
+**/.swiftpm/
+**/.DS_Store
+Package.resolved
+**/Package.resolved

--- a/.gitattributes
+++ b/.gitattributes
@@ -13,6 +13,9 @@
 # Vendored Boost headers in Sources should be marked as vendored
 Sources/*/include/** linguist-vendored
 
+# Hand-written modulemap stubs are not vendored Boost source
+Sources/*/include/module.modulemap linguist-generated
+
 # SPM build stubs (not real source code)
 Sources/BoostTestHelpers/**             linguist-vendored
 Sources/*/src/*.cpp                     linguist-vendored

--- a/.github/workflows/apple-builds.yml
+++ b/.github/workflows/apple-builds.yml
@@ -1,0 +1,63 @@
+name: Apple Platforms
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  macos:
+    name: macOS
+    runs-on: macos-26
+    permissions:
+      contents: read
+    env:
+      DEVELOPER_DIR: "/Applications/Xcode_26.4.app/Contents/Developer"
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build and test
+        run: swift test
+      - name: Build LinuxConsumerProbe (external-consumer regression coverage)
+        working-directory: Examples/LinuxConsumerProbe
+        run: swift build
+
+  ios:
+    name: iOS
+    runs-on: macos-26
+    permissions:
+      contents: read
+    env:
+      SCHEME: Boost-Package
+      DEVELOPER_DIR: "/Applications/Xcode_26.4.app/Contents/Developer"
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build for iOS
+        run: |
+          xcrun xcodebuild \
+            -skipMacroValidation \
+            -skipPackagePluginValidation \
+            build \
+            -scheme "$SCHEME" \
+            -destination generic/platform=iOS
+
+  visionos:
+    name: visionOS
+    runs-on: macos-26
+    permissions:
+      contents: read
+    env:
+      SCHEME: Boost-Package
+      DEVELOPER_DIR: "/Applications/Xcode_26.4.app/Contents/Developer"
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build for visionOS
+        run: |
+          xcrun xcodebuild \
+            -skipMacroValidation \
+            -skipPackagePluginValidation \
+            build \
+            -scheme "$SCHEME" \
+            -destination generic/platform=visionOS

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -1,0 +1,20 @@
+name: Docker Builds
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  linux:
+    name: Linux
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build and test
+        run: docker build .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,58 @@
+# AGENTS.md (swift-boost)
+
+A header-aggregator SwiftPM package vendoring [Boost](https://www.boost.org/) 1.90.0 C++ headers as 37 individual library products plus a `boost` umbrella product. Supports macOS 13+ and Linux (Ubuntu 22.04+). Uses C++17 (`cxxLanguageStandard: .cxx17`) and is consumed via Swift's [C++ interoperability](https://www.swift.org/documentation/cxx-interop/) (`interoperabilityMode(.Cxx)`).
+
+## Commands
+
+- Build: `swift build`
+- Test: `swift test`
+- Linux verify: `docker build .` (builds + tests on `swift:6.3`, then builds `Examples/LinuxConsumerProbe`)
+- Probe build (any platform): `cd Examples/LinuxConsumerProbe && swift build`
+
+## Non-obvious patterns
+
+- **Stub modulemaps for Linux**: every `Sources/<module>/include/module.modulemap` declares an empty module with `requires !cplusplus`. On Linux, Swift defaults to `-fno-implicit-modules` while C++ interop forces `-fmodules`; without a modulemap, the build fails with "module needed but not provided." The `requires !cplusplus` clause makes the modulemap not match any C++ TU, falling through to textual `#include`. Without these stubs shipped in the package, downstream consumers like swift-bitcoin need a post-resolve workaround that injects them after `swift package resolve`.
+- **Two consumption patterns**: per-module products (`assert`, `optional`, `multi_index`, ...) for fine-grained control, plus a `boost` umbrella product whose target depends on every module. Consumers using a wide cross-section (e.g. Bitcoin Core ports) prefer the umbrella; consumers needing only one or two modules use them individually.
+- **Header-only with stub `.cpp`**: SPM requires at least one source file per target. Each module has a near-empty `<module>.cpp` under `Sources/<module>/src/` that exists only to satisfy SPM. No Boost source is compiled. `Sources/boost/src/boost.cpp` plays the same role for the umbrella.
+- **Extraction flow**: `subtree.yaml` is the source of truth for which Boost modules are vendored and at which upstream tag. The [`swift-plugin-subtree`](https://github.com/21-DOT-DEV/swift-plugin-subtree) plugin extracts headers via `git subtree`. Do NOT edit `Sources/<module>/include/boost/**` directly — those paths are overwritten on the next extraction.
+- **`container` is incomplete**: `boost::container` (vector, map, etc.) transitively requires `boost::intrusive`, which is not currently shipped. The module's `-I` path is reachable but the full container types fail to compile. Use `<boost/container/container_fwd.hpp>` (forward decls only) for now. Fix is to subtree `intrusive` into `subtree.yaml` + add it to `Package.swift`.
+- **Boost umbrella headers can pull in unshipped modules**: `<boost/signals2.hpp>` pulls `boost::parameter` (not shipped). Per-feature headers like `<boost/signals2/signal.hpp>` are the right choice. `Examples/LinuxConsumerProbe/Sources/AllModulesConsumer/include/probe.h` documents the canonical-header choice per module.
+- **Versioning mirrors upstream Boost**: tags follow Boost releases (`1.80.0`, `1.81.0`, `1.90.0`). The `subtree-1.81.0` tag was a one-off subtree-migration milestone, not a Boost release. Recommend consumers pin with `exact:` because Boost minor releases can deprecate or remove modules.
+
+## External-consumer regression coverage
+
+`Examples/LinuxConsumerProbe` is a separate SPM package that depends on swift-boost via `path: "../.."`. It builds four target shapes mirroring real downstream consumption:
+
+- `UmbrellaConsumer` — depends on `boost`; uses a swift-bitcoin-representative header subset.
+- `IndividualConsumer` — depends on the swift-bitcoin-specific 27-module subset; same header subset.
+- `AllModulesConsumer` — depends on every individual product with one canonical header per module. Catches regressions when a new module is added with a broken stub modulemap.
+- `SwiftConsumer` + `SwiftConsumerCxx` — Swift target with `interoperabilityMode(.Cxx)` consuming a C++ shim that depends on `boost`. Mirrors swift-bitcoin's actual Swift→Boost path across a package boundary.
+
+The Dockerfile builds all four; `.github/workflows/docker-builds.yml` runs the same Dockerfile in CI, and `apple-builds.yml`'s macOS job also builds the probe.
+
+## Adding a new Boost module
+
+1. Add the upstream subtree entry to `subtree.yaml`.
+2. Run the SubtreePlugin to materialize headers under `Sources/<module>/include/boost/`.
+3. Create `Sources/<module>/include/module.modulemap` matching existing stubs (`module <name>_modulemap_stub { requires !cplusplus }`).
+4. Add the module name to `boostModules` in `Package.swift`.
+5. Add a canonical header for the module to `Examples/LinuxConsumerProbe/Sources/AllModulesConsumer/include/probe.h` so future modulemap regressions surface in CI.
+6. Verify: `swift build && swift test && docker build .`.
+
+## Boundaries
+
+- **Never**: edit `Sources/<module>/include/boost/**` directly (overwritten on next subtree extraction); replace `requires !cplusplus` modulemaps with concrete `header` declarations (would re-break Linux's `-fno-implicit-modules`); broaden GitHub Actions `permissions` without justification.
+- **Ask first**: add a new Boost module not in `subtree.yaml`; modify the `boostModules` list in `Package.swift` without a corresponding `subtree.yaml` change; alter the `boost` umbrella's dependency list.
+- See the [21-DOT-DEV contributing guidelines](https://github.com/21-DOT-DEV/.github/blob/main/CONTRIBUTING.md) for branching and commit guidelines. See the [21-DOT-DEV SECURITY.md](https://github.com/21-DOT-DEV/.github/blob/main/SECURITY.md) for vulnerability reporting.
+
+## Scoped guidance
+
+Directory-specific `AGENTS.md` files provide additional context:
+
+- [`Sources/AGENTS.md`](Sources/AGENTS.md) — per-module structure, modulemap stubs, BoostTestHelpers carve-out, adding-a-module workflow
+- [`Examples/LinuxConsumerProbe/AGENTS.md`](Examples/LinuxConsumerProbe/AGENTS.md) — probe targets, SPM package-identity caveat, known incomplete edges (`container`/`intrusive`, `signals2` umbrella)
+
+## Maintenance
+
+- Update when build/test workflows, Boost version, platform support, or shipped modules change.
+- The "Non-obvious patterns" section is the most load-bearing — keep it current with caveats discovered in real consumer integrations.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM swift:6.3
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates git pkg-config && \
+    rm -rf /var/lib/apt/lists/*
+WORKDIR /swift-boost
+COPY . .
+RUN swift --version
+
+# swift-boost itself: build all targets and run BoostTests, which exercises
+# Swift/C++ interop via BoostTestHelpers (clamp/optional/variant). The shipped
+# `requires !cplusplus` modulemaps let Linux's -fno-implicit-modules default
+# fall through to textual #include without any post-resolve injection.
+RUN swift build
+RUN swift test
+
+# External-consumer probe: depends on swift-boost via local path. Exercises
+# both the new `boost` umbrella product and the existing per-module products
+# as a swift-bitcoin-style consumer would, catching regressions in either
+# resolution path on Linux.
+RUN cd Examples/LinuxConsumerProbe && swift build
+
+CMD ["swift", "test"]

--- a/Examples/LinuxConsumerProbe/AGENTS.md
+++ b/Examples/LinuxConsumerProbe/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md (Examples/LinuxConsumerProbe)
+
+This is a separate SPM package, NOT a target inside swift-boost. It depends on the parent package via `.package(path: "../..")` and exists to verify external-consumer behavior — particularly on Linux's `-fno-implicit-modules` default, where regressions in swift-boost's modulemaps would break downstream consumers like swift-bitcoin.
+
+## Targets
+
+- **`UmbrellaConsumer`** — depends on the `boost` umbrella product. `include/probe.h` includes a swift-bitcoin-representative subset of headers (`multi_index_container`, `signals2/signal`, `operators`, `tuple`, etc.).
+- **`IndividualConsumer`** — depends on the swift-bitcoin-specific 27-module subset directly (no umbrella). Same header subset as `UmbrellaConsumer`. Catches regressions in per-product `-I` propagation along swift-bitcoin's actual usage path.
+- **`AllModulesConsumer`** — depends on every individual product (all 37). `include/probe.h` includes one canonical header per module. Catches stub-modulemap regressions when a new module is added.
+- **`SwiftConsumer`** + **`SwiftConsumerCxx`** — Swift target with `interoperabilityMode(.Cxx)` consuming a C++ shim that depends on `boost`. Mirrors swift-bitcoin's actual Swift→Boost path across a package boundary, which `Tests/BoostTests` can't cover from inside swift-boost itself.
+
+## Non-obvious patterns
+
+- **SPM package identity matches the parent directory name.** `dependencies: [.package(path: "../..")]` resolves the parent package's identity from the directory name (`swift-boost`). If the parent is checked out under a different directory name, `Package.swift`'s `.product(name: ..., package: "swift-boost")` references will fail to resolve. The Dockerfile's `WORKDIR` is set to `/swift-boost` for this reason.
+- **`probe.h` carries the `#include`s, not `probe.cpp`.** Putting Boost includes in the public header proves `-I` paths reach downstream targets transitively — the path a real library consumer's public surface would exercise. Each `probe.cpp` is a one-liner that pulls the header in to force compilation.
+- **`AllModulesConsumer` documents canonical-header choices.** Several Boost modules ship umbrella headers (`<boost/<mod>.hpp>`) that transitively `#include` modules swift-boost does NOT ship. The probe's `include/probe.h` documents the safe canonical header per module — comments call out each module name. When adding a new module, add its safe canonical header here.
+- **`SwiftConsumerCxx` mirrors `BoostTestHelpers`** but lives in a separate package. The wrapping pattern (type aliases, thin functions) is identical — Swift cannot import Boost templates directly. The two files exist independently because `Tests/BoostTests` is internal to swift-boost; `SwiftConsumer` is the external-package equivalent.
+
+## Known incomplete edges
+
+- **`<boost/container/vector.hpp>` (and most full container types) cannot be reached** because they transitively `#include <boost/intrusive/...>`, which swift-boost does not ship. `AllModulesConsumer/include/probe.h` uses `<boost/container/container_fwd.hpp>` (forward declarations only). Fix: add `intrusive` as a module to `subtree.yaml` + `Package.swift`.
+- **`<boost/signals2.hpp>` (umbrella header) pulls in `boost::parameter`**, which swift-boost does not ship. Use `<boost/signals2/signal.hpp>` (per-feature header) instead. The probes follow this convention.
+
+## Workflow integration
+
+- `Dockerfile` builds all four targets (`docker build .`).
+- `.github/workflows/docker-builds.yml` runs the same Dockerfile in CI.
+- `.github/workflows/apple-builds.yml`'s macOS job also builds the probe (`Build LinuxConsumerProbe (external-consumer regression coverage)` step) — exercises Apple-side external-consumer behavior, not just Linux.

--- a/Examples/LinuxConsumerProbe/Package.swift
+++ b/Examples/LinuxConsumerProbe/Package.swift
@@ -1,0 +1,61 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let umbrellaDeps: [Target.Dependency] = [
+    .product(name: "boost", package: "swift-boost"),
+]
+
+// Mirrors swift-bitcoin's current production consumption pattern to provide
+// regression coverage for the existing per-module API on Linux.
+let swiftBitcoinModules: [String] = [
+    "assert", "bind", "config", "container_hash", "core", "describe",
+    "detail", "foreach", "function", "integer", "iterator", "move",
+    "mp11", "mpl", "multi_index", "optional", "preprocessor",
+    "serialization", "signals2", "smart_ptr", "static_assert",
+    "throw_exception", "tuple", "type_index", "type_traits",
+    "utility", "variant",
+]
+
+// Every module shipped by swift-boost. Keeping a target wired to the full
+// list catches stub-modulemap regressions in any newly-subtree'd module
+// before downstream consumers inherit them.
+let allBoostModules: [String] = [
+    "algorithm", "array", "assert", "bind", "concept_check", "config",
+    "container", "container_hash", "core", "date_time", "describe", "detail",
+    "foreach", "function", "integer", "io", "iterator", "lexical_cast",
+    "move", "mp11", "mpl", "multi_index", "numeric_conversion", "optional",
+    "preprocessor", "range", "serialization", "signals2", "smart_ptr",
+    "static_assert", "throw_exception", "tokenizer", "tuple", "type_index",
+    "type_traits", "utility", "variant",
+]
+
+let individualDeps: [Target.Dependency] = swiftBitcoinModules.map {
+    .product(name: $0, package: "swift-boost")
+}
+
+let allModulesDeps: [Target.Dependency] = allBoostModules.map {
+    .product(name: $0, package: "swift-boost")
+}
+
+let package = Package(
+    name: "LinuxConsumerProbe",
+    products: [
+        .library(name: "UmbrellaConsumer", targets: ["UmbrellaConsumer"]),
+        .library(name: "IndividualConsumer", targets: ["IndividualConsumer"]),
+        .library(name: "AllModulesConsumer", targets: ["AllModulesConsumer"]),
+        .library(name: "SwiftConsumer", targets: ["SwiftConsumer"]),
+    ],
+    dependencies: [.package(path: "../..")],
+    targets: [
+        .target(name: "UmbrellaConsumer", dependencies: umbrellaDeps),
+        .target(name: "IndividualConsumer", dependencies: individualDeps),
+        .target(name: "AllModulesConsumer", dependencies: allModulesDeps),
+        .target(name: "SwiftConsumerCxx", dependencies: umbrellaDeps),
+        .target(
+            name: "SwiftConsumer",
+            dependencies: ["SwiftConsumerCxx"],
+            swiftSettings: [.interoperabilityMode(.Cxx)]
+        ),
+    ],
+    cxxLanguageStandard: .cxx17
+)

--- a/Examples/LinuxConsumerProbe/Sources/AllModulesConsumer/include/probe.h
+++ b/Examples/LinuxConsumerProbe/Sources/AllModulesConsumer/include/probe.h
@@ -1,0 +1,50 @@
+#pragma once
+
+// Includes one canonical header from every Boost module shipped by
+// swift-boost. If a future module is added with a broken stub modulemap
+// or a missing -I path, the build of this target will fail before any
+// downstream consumer (e.g. swift-bitcoin) ever sees the regression.
+//
+// Note on `container`: the full container types (vector, map, etc.)
+// transitively #include boost/intrusive, which swift-boost does not
+// currently ship. We use container_fwd.hpp here so the probe still
+// proves the container module's -I path is reachable; using the heavy
+// containers requires adding the intrusive module to swift-boost.
+
+#include <boost/algorithm/algorithm.hpp>           // algorithm
+#include <boost/array.hpp>                         // array
+#include <boost/assert.hpp>                        // assert
+#include <boost/bind.hpp>                          // bind
+#include <boost/concept_check.hpp>                 // concept_check
+#include <boost/config.hpp>                        // config
+#include <boost/container/container_fwd.hpp>       // container (see note below)
+#include <boost/container_hash/hash.hpp>           // container_hash
+#include <boost/core/noncopyable.hpp>              // core
+#include <boost/date_time.hpp>                     // date_time
+#include <boost/describe.hpp>                      // describe
+#include <boost/blank.hpp>                         // detail
+#include <boost/foreach.hpp>                       // foreach
+#include <boost/function.hpp>                      // function
+#include <boost/integer.hpp>                       // integer
+#include <boost/io/ios_state.hpp>                  // io
+#include <boost/iterator/iterator_facade.hpp>      // iterator
+#include <boost/lexical_cast.hpp>                  // lexical_cast
+#include <boost/move/move.hpp>                     // move
+#include <boost/mp11.hpp>                          // mp11
+#include <boost/mpl/vector.hpp>                    // mpl
+#include <boost/multi_index_container.hpp>         // multi_index
+#include <boost/numeric/conversion/cast.hpp>       // numeric_conversion
+#include <boost/optional.hpp>                      // optional
+#include <boost/preprocessor.hpp>                  // preprocessor
+#include <boost/range.hpp>                         // range
+#include <boost/serialization/serialization.hpp>   // serialization
+#include <boost/signals2/signal.hpp>               // signals2
+#include <boost/smart_ptr.hpp>                     // smart_ptr
+#include <boost/static_assert.hpp>                 // static_assert
+#include <boost/throw_exception.hpp>               // throw_exception
+#include <boost/tokenizer.hpp>                     // tokenizer
+#include <boost/tuple/tuple.hpp>                   // tuple
+#include <boost/type_index.hpp>                    // type_index
+#include <boost/type_traits.hpp>                   // type_traits
+#include <boost/utility.hpp>                       // utility
+#include <boost/variant.hpp>                       // variant

--- a/Examples/LinuxConsumerProbe/Sources/AllModulesConsumer/probe.cpp
+++ b/Examples/LinuxConsumerProbe/Sources/AllModulesConsumer/probe.cpp
@@ -1,0 +1,1 @@
+#include "probe.h"

--- a/Examples/LinuxConsumerProbe/Sources/IndividualConsumer/include/probe.h
+++ b/Examples/LinuxConsumerProbe/Sources/IndividualConsumer/include/probe.h
@@ -1,0 +1,17 @@
+#pragma once
+
+// Public surface of this probe target. Putting the Boost #includes in the
+// public header (rather than the .cpp) verifies -I propagation along the
+// path a real downstream consumer would exercise: anything that depends on
+// IndividualConsumer must be able to resolve Boost headers transitively.
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/signals2/signal.hpp>
+#include <boost/operators.hpp>
+#include <boost/tuple/tuple.hpp>
+
+namespace probe_individual {
+    using SignalT = boost::signals2::signal<void()>;
+    using TupleT  = boost::tuple<int, int>;
+}

--- a/Examples/LinuxConsumerProbe/Sources/IndividualConsumer/probe.cpp
+++ b/Examples/LinuxConsumerProbe/Sources/IndividualConsumer/probe.cpp
@@ -1,0 +1,1 @@
+#include "probe.h"

--- a/Examples/LinuxConsumerProbe/Sources/SwiftConsumer/SwiftConsumer.swift
+++ b/Examples/LinuxConsumerProbe/Sources/SwiftConsumer/SwiftConsumer.swift
@@ -1,0 +1,18 @@
+import SwiftConsumerCxx
+
+// Swift external-consumer probe. Importing SwiftConsumerCxx (which itself
+// depends on the `boost` umbrella) verifies that swift-boost's -I paths
+// reach swiftc's clang importer across a package boundary — the path
+// swift-bitcoin actually exercises and that BoostTests cannot cover from
+// inside swift-boost itself.
+public enum SwiftConsumer {
+
+    public static func clamp(_ value: CInt, lo: CInt, hi: CInt) -> CInt {
+        boost_clamp(value, lo, hi)
+    }
+
+    public static func optional(_ value: CInt) -> CInt {
+        let opt = BoostOptionalInt(value)
+        return boost_optional_value(opt)
+    }
+}

--- a/Examples/LinuxConsumerProbe/Sources/SwiftConsumerCxx/SwiftConsumerCxx.cpp
+++ b/Examples/LinuxConsumerProbe/Sources/SwiftConsumerCxx/SwiftConsumerCxx.cpp
@@ -1,0 +1,1 @@
+// Required by SPM (minimum one source file per target)

--- a/Examples/LinuxConsumerProbe/Sources/SwiftConsumerCxx/include/SwiftConsumerCxx.h
+++ b/Examples/LinuxConsumerProbe/Sources/SwiftConsumerCxx/include/SwiftConsumerCxx.h
@@ -1,0 +1,19 @@
+#pragma once
+
+// Thin C++ shim used by the SwiftConsumer probe to verify swift-boost's
+// per-target -I paths reach the clang importer that swiftc invokes during
+// Swift/C++ interop builds in *external* packages. Mirrors the wrapping
+// pattern documented in BoostTestHelpers — Boost templates rarely import
+// directly into Swift.
+#include <boost/algorithm/clamp.hpp>
+#include <boost/optional.hpp>
+
+using BoostOptionalInt = boost::optional<int>;
+
+inline int boost_optional_value(const boost::optional<int> &opt) {
+    return opt.get();
+}
+
+inline int boost_clamp(int value, int lo, int hi) {
+    return boost::algorithm::clamp(value, lo, hi);
+}

--- a/Examples/LinuxConsumerProbe/Sources/UmbrellaConsumer/include/probe.h
+++ b/Examples/LinuxConsumerProbe/Sources/UmbrellaConsumer/include/probe.h
@@ -1,0 +1,17 @@
+#pragma once
+
+// Public surface of this probe target. Putting the Boost #includes in the
+// public header (rather than the .cpp) verifies -I propagation along the
+// path a real downstream consumer would exercise: anything that depends on
+// UmbrellaConsumer must be able to resolve Boost headers transitively.
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/signals2/signal.hpp>
+#include <boost/operators.hpp>
+#include <boost/tuple/tuple.hpp>
+
+namespace probe_umbrella {
+    using SignalT = boost::signals2::signal<void()>;
+    using TupleT  = boost::tuple<int, int>;
+}

--- a/Examples/LinuxConsumerProbe/Sources/UmbrellaConsumer/probe.cpp
+++ b/Examples/LinuxConsumerProbe/Sources/UmbrellaConsumer/probe.cpp
@@ -1,0 +1,1 @@
+#include "probe.h"

--- a/Package.swift
+++ b/Package.swift
@@ -19,11 +19,16 @@ let boostIncludePaths: (String) -> [CXXSetting] = { prefix in
 
 let package = Package(
     name: "Boost",
-    products: boostModules.map { .library(name: $0, targets: [$0]) },
+    products: boostModules.map { .library(name: $0, targets: [$0]) }
+        + [.library(name: "boost", targets: ["boost"])],
     dependencies: [
         .package(url: "https://github.com/21-DOT-DEV/swift-plugin-subtree.git", exact: "0.0.12")
     ],
     targets: boostModules.map { .target(name: $0) } + [
+        .target(
+            name: "boost",
+            dependencies: boostModules.map { .target(name: $0) }
+        ),
         .target(name: "BoostTestHelpers", cxxSettings: boostIncludePaths("../")),
         .testTarget(
             name: "BoostTests",

--- a/README.md
+++ b/README.md
@@ -1,24 +1,38 @@
-[![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Apple Platforms](https://github.com/21-DOT-DEV/swift-boost/actions/workflows/apple-builds.yml/badge.svg)](https://github.com/21-DOT-DEV/swift-boost/actions/workflows/apple-builds.yml) [![Docker Builds](https://github.com/21-DOT-DEV/swift-boost/actions/workflows/docker-builds.yml/badge.svg)](https://github.com/21-DOT-DEV/swift-boost/actions/workflows/docker-builds.yml) [![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![Swift Versions](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2F21-DOT-DEV%2Fswift-boost%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/21-DOT-DEV/swift-boost) [![Platforms](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2F21-DOT-DEV%2Fswift-boost%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/21-DOT-DEV/swift-boost)
 
-# swift-boost
+# 🚀 swift-boost
 
 Vendored [Boost](https://www.boost.org/) 1.90.0 C++ header-only modules for Swift packages. Uses Swift's [C++ interoperability](https://www.swift.org/documentation/cxx-interop/) to make Boost headers available to Swift targets.
+
+```swift
+.package(url: "https://github.com/21-DOT-DEV/swift-boost.git", exact: "1.90.0"),
+```
+
+## Why swift-boost?
+
+Reach for `swift-boost` when you need a wide cross-section of header-only Boost in a SwiftPM-native form across Apple platforms and Linux — for example, Bitcoin Core ports like [swift-bitcoin](https://github.com/21-DOT-DEV/swift-bitcoin) that consume `multi_index`, `signals2`, `mp11`, and dozens of other modules. The 37 modules ship as individual library products plus a `boost` umbrella, so you don't have to subtree Boost into your own package or hand-write per-module SPM wiring.
+
+Don't reach for it if you only need one or two header-only Boost modules — subtree-ing them directly into your own package is simpler and avoids taking a dependency. And if your goal is portable C++ standard-library functionality, modern C++17/20 (`std::variant`, `std::optional`, `std::filesystem`) covers a lot of what Boost historically provided without any vendored dependency.
 
 ## Contents
 
 - [Features](#features)
 - [Available Modules](#available-modules)
 - [Installation](#installation)
+- [Versioning](#versioning)
 - [Usage](#usage)
 - [Development](#development)
+- [Contributing](#contributing)
+- [Security](#security)
 - [License](#license)
 
 ## Features
 
-- Provide 37 Boost C++ header-only modules as individual SwiftPM library products
-- Enable Swift/C++ interop consumption of Boost types and algorithms
-- Support macOS and Linux (Swift 6.1+, C++17)
-- Extract only public headers — no Boost source compilation required
+- **37 Boost modules** as individual SwiftPM library products, plus a `boost` umbrella product mirroring upstream Boost's CMake `Boost::headers` target
+- **Swift/C++ interop ready** — pair with a C++ bridging header to call Boost from Swift via `interoperabilityMode(.Cxx)`
+- **Apple platforms + Linux** — macOS 13+, iOS, visionOS, and Ubuntu 22.04+ (Swift 6.1+, C++17)
+- **Header-only** — no Boost source compilation; ships only public headers
+- **Linux-native modulemaps** — ships `requires !cplusplus` modulemap stubs so consumers don't need post-resolve workarounds for Swift's `-fno-implicit-modules` default
 
 ## Available Modules
 
@@ -36,25 +50,30 @@ Each Boost module is exposed as an individual SwiftPM library product.
 
 See [`Package.swift`](Package.swift) for the complete list of all 37 modules.
 
+A `boost` umbrella product is also available, mirroring upstream Boost's CMake `Boost::headers` target. Depending on `boost` brings in every module's headers transitively, which is convenient for consumers (such as Bitcoin Core ports) that use a wide cross-section of Boost.
+
 ## Installation
 
-This package uses Swift Package Manager. To add it to your project:
+This package uses Swift Package Manager.
 
 ### Using Xcode
 
 1. Go to `File > Add Packages...`
 2. Enter the package URL: `https://github.com/21-DOT-DEV/swift-boost`
-3. Select the desired version
+3. Select the desired version (recommend pinning to an exact version — see [Versioning](#versioning))
 
 ### Using Package.swift (Recommended)
 
-Add the following to your `Package.swift` file:
+Add the following to your `Package.swift`:
 
 ```swift
-.package(url: "https://github.com/21-DOT-DEV/swift-boost.git", from: "0.1.0"),
+.package(url: "https://github.com/21-DOT-DEV/swift-boost.git", exact: "1.90.0"),
 ```
 
-Then, add the Boost modules you need as dependencies and enable C++ interop:
+> [!NOTE]
+> swift-boost tags mirror upstream Boost releases. Pin with `exact:` because Boost minor releases can deprecate or remove modules. See [Versioning](#versioning) below.
+
+Then add the Boost modules you need as dependencies and enable C++ interop on the consuming target:
 
 ```swift
 .target(
@@ -63,8 +82,19 @@ Then, add the Boost modules you need as dependencies and enable C++ interop:
         .product(name: "algorithm", package: "swift-boost"),
         .product(name: "optional", package: "swift-boost"),
     ],
-    cxxSettings: [
-        .headerSearchPath("path/to/boost/module/include"),
+    swiftSettings: [
+        .interoperabilityMode(.Cxx),
+    ]
+),
+```
+
+For consumers using a wide cross-section of Boost, depend on the umbrella product instead:
+
+```swift
+.target(
+    name: "MyTarget",
+    dependencies: [
+        .product(name: "boost", package: "swift-boost"),
     ],
     swiftSettings: [
         .interoperabilityMode(.Cxx),
@@ -72,10 +102,27 @@ Then, add the Boost modules you need as dependencies and enable C++ interop:
 ),
 ```
 
+Set `cxxLanguageStandard: .cxx17` (or higher) at the package level.
+
+## Versioning
+
+swift-boost tags mirror upstream Boost releases. Recent tags:
+
+| Tag | Boost upstream |
+|---|---|
+| `1.90.0` | Boost 1.90.0 |
+| `1.81.0` | Boost 1.81.0 |
+| `1.80.0` | Boost 1.80.0 |
+
+> [!NOTE]
+> Boost minor releases can deprecate or remove modules. Pin consumers with `exact:` so you choose explicitly when to take on Boost upstream changes — `from:` would auto-uptake new Boost releases and expose your package to module-surface churn.
+
+The `subtree-1.81.0` tag in the repository's tag list is a one-off subtree-migration milestone, not a Boost release; ignore it for normal version selection.
+
 ## Usage
 
 > [!NOTE]
-> This package provides C++ headers, not Swift wrapper APIs. To use Boost types from Swift, you need a C++ bridging header with explicit type aliases and thin wrappers. This is a requirement of Swift/C++ interop — not all C++ patterns import directly.
+> This package provides C++ headers, not Swift wrapper APIs. To use Boost types from Swift, you need a C++ bridging header with explicit type aliases and thin wrappers. This is a requirement of Swift/C++ interop — not all C++ patterns import directly into Swift.
 
 ### C++ Bridging Header
 
@@ -114,7 +161,7 @@ let value = boost_optional_value(opt)  // 42
 ```
 
 > [!NOTE]
-> For more details on Swift/C++ interop patterns (type aliases for class templates, wrapping function templates, interior pointer limitations), see [Swift C++ Interop documentation](https://www.swift.org/documentation/cxx-interop/).
+> For more detail on Swift/C++ interop patterns (type aliases for class templates, wrapping function templates, interior pointer limitations), see the [Swift C++ Interop documentation](https://www.swift.org/documentation/cxx-interop/). For a working external-consumer example, see [`Examples/LinuxConsumerProbe`](Examples/LinuxConsumerProbe).
 
 ## Development
 
@@ -124,16 +171,21 @@ let value = boost_optional_value(opt)  // 42
 - C++17
 - macOS 13+ or Linux
 
-### Project Structure
+### Linux build verification
 
+```bash
+docker build .
 ```
-Sources/
-├── algorithm/          # Boost.Algorithm headers (include/boost/algorithm/)
-├── optional/           # Boost.Optional headers (include/boost/optional/)
-├── variant/            # Boost.Variant headers (include/boost/variant/)
-├── ...                 # 34 more Boost modules
-└── BoostTestHelpers/   # C++ bridging header for tests
-```
+
+The included [`Dockerfile`](Dockerfile) builds and tests the package on `swift:6.3`, then builds [`Examples/LinuxConsumerProbe`](Examples/LinuxConsumerProbe) — an external-consumer smoke test that exercises the `boost` umbrella, the per-module products, all 37 modules in one translation unit, and a Swift target consuming Boost via C++ interop across a package boundary.
+
+## Contributing
+
+Contributions are welcome. Read the [21-DOT-DEV contributing guidelines](https://github.com/21-DOT-DEV/.github/blob/main/CONTRIBUTING.md) for general workflow, and [AGENTS.md](AGENTS.md) for project-specific architecture notes (modulemap stubs, subtree extraction flow, adding a new Boost module).
+
+## Security
+
+For information on reporting security vulnerabilities, see the [21-DOT-DEV SECURITY.md](https://github.com/21-DOT-DEV/.github/blob/main/SECURITY.md).
 
 ## License
 

--- a/Sources/AGENTS.md
+++ b/Sources/AGENTS.md
@@ -1,0 +1,42 @@
+# AGENTS.md (Sources)
+
+This directory contains the 37 Boost module targets, the `boost` umbrella target, and `BoostTestHelpers` (the C++ shim used by `Tests/BoostTests`).
+
+## What lives here
+
+- **37 Boost module targets**: `algorithm/`, `array/`, `assert/`, `bind/`, `concept_check/`, `config/`, `container/`, `container_hash/`, `core/`, `date_time/`, `describe/`, `detail/`, `foreach/`, `function/`, `integer/`, `io/`, `iterator/`, `lexical_cast/`, `move/`, `mp11/`, `mpl/`, `multi_index/`, `numeric_conversion/`, `optional/`, `preprocessor/`, `range/`, `serialization/`, `signals2/`, `smart_ptr/`, `static_assert/`, `throw_exception/`, `tokenizer/`, `tuple/`, `type_index/`, `type_traits/`, `utility/`, `variant/` — each is one Boost upstream module's headers.
+- **`boost/`**: umbrella target whose `Package.swift` declaration depends on every module above. Provides the `boost` library product.
+- **`BoostTestHelpers/`**: NOT one of the 37 modules. C++ shim that wraps Boost templates into Swift-importable signatures (type aliases, thin functions). Used only by `Tests/BoostTests`.
+
+## Per-module structure
+
+Every Boost module target is laid out as:
+
+```
+Sources/<module>/
+├── include/
+│   ├── boost/                     # extracted upstream headers (DO NOT EDIT)
+│   │   └── <upstream layout>/
+│   └── module.modulemap           # stub: `requires !cplusplus`
+└── src/
+    └── <module>.cpp               # SPM-appeasement stub
+```
+
+The umbrella `Sources/boost/` follows the same shape (`include/module.modulemap` + `src/boost.cpp`).
+
+## Non-obvious patterns
+
+- **`include/boost/**` is extracted, not authored.** `subtree.yaml` declares the upstream Boost repo + tag for each module; the `swift-plugin-subtree` plugin populates `include/boost/...` via `git subtree`. Hand edits in this subtree are overwritten on the next extraction.
+- **`include/module.modulemap` is the Linux fix.** The stub declares `module <name>_modulemap_stub { requires !cplusplus }` — it never matches a C++ TU, so the build falls through to textual `#include`. Without this, Linux's `-fno-implicit-modules` default fails when Swift/C++ interop forces `-fmodules`. Do NOT replace the `requires !cplusplus` with concrete `header` declarations — it would re-break Linux for downstream consumers.
+- **`src/<module>.cpp` exists only to satisfy SPM.** SPM requires at least one source file per target; Boost compiles nothing. The `.cpp` files are near-empty and flagged `linguist-generated` in `.gitattributes` so GitHub doesn't count them as authored code.
+- **The `boost` umbrella has no extracted headers.** Its `include/boost/` is intentionally absent — the umbrella exists purely for transitive `-I` propagation via its dependency list in `Package.swift`.
+- **`BoostTestHelpers` is the cxx-interop shim.** Boost templates often don't import directly to Swift (function templates need explicit instantiation; reference returns are interior pointers; heavy MPL exceeds clang importer template depth). `BoostTestHelpers/include/BoostTestHelpers.h` wraps these into Swift-callable signatures. Mirror this pattern when adding tests.
+
+## Adding a new Boost module
+
+1. Add an entry to `subtree.yaml` (path: `Sources/<module>`, repo, tag).
+2. Run the SubtreePlugin to extract upstream headers under `Sources/<module>/include/boost/`.
+3. Create `Sources/<module>/include/module.modulemap` matching existing stubs (`module <name>_modulemap_stub { requires !cplusplus }`).
+4. Create `Sources/<module>/src/<module>.cpp` (one-line comment is fine).
+5. Add the module name to `boostModules` in `Package.swift`.
+6. Add a canonical header to `Examples/LinuxConsumerProbe/Sources/AllModulesConsumer/include/probe.h`.

--- a/Sources/algorithm/include/module.modulemap
+++ b/Sources/algorithm/include/module.modulemap
@@ -1,0 +1,4 @@
+module algorithm {
+    requires !cplusplus
+    export *
+}

--- a/Sources/array/include/module.modulemap
+++ b/Sources/array/include/module.modulemap
@@ -1,0 +1,4 @@
+module array {
+    requires !cplusplus
+    export *
+}

--- a/Sources/assert/include/module.modulemap
+++ b/Sources/assert/include/module.modulemap
@@ -1,0 +1,4 @@
+module assert {
+    requires !cplusplus
+    export *
+}

--- a/Sources/bind/include/module.modulemap
+++ b/Sources/bind/include/module.modulemap
@@ -1,0 +1,4 @@
+module bind {
+    requires !cplusplus
+    export *
+}

--- a/Sources/boost/include/module.modulemap
+++ b/Sources/boost/include/module.modulemap
@@ -1,0 +1,4 @@
+module boost {
+    requires !cplusplus
+    export *
+}

--- a/Sources/boost/src/boost.cpp
+++ b/Sources/boost/src/boost.cpp
@@ -1,0 +1,12 @@
+//
+//  boost.cpp
+//  21-DOT-DEV/swift-boost
+//
+//  Copyright (c) 2026 Timechain Software Initiative, Inc.
+//  Distributed under the MIT software license
+//
+//  See the accompanying file LICENSE for information
+//
+
+
+//  This file only exists for automatic module generation

--- a/Sources/concept_check/include/module.modulemap
+++ b/Sources/concept_check/include/module.modulemap
@@ -1,0 +1,4 @@
+module concept_check {
+    requires !cplusplus
+    export *
+}

--- a/Sources/config/include/module.modulemap
+++ b/Sources/config/include/module.modulemap
@@ -1,0 +1,4 @@
+module config {
+    requires !cplusplus
+    export *
+}

--- a/Sources/container/include/module.modulemap
+++ b/Sources/container/include/module.modulemap
@@ -1,0 +1,4 @@
+module container {
+    requires !cplusplus
+    export *
+}

--- a/Sources/container_hash/include/module.modulemap
+++ b/Sources/container_hash/include/module.modulemap
@@ -1,0 +1,4 @@
+module container_hash {
+    requires !cplusplus
+    export *
+}

--- a/Sources/core/include/module.modulemap
+++ b/Sources/core/include/module.modulemap
@@ -1,0 +1,4 @@
+module core {
+    requires !cplusplus
+    export *
+}

--- a/Sources/date_time/include/module.modulemap
+++ b/Sources/date_time/include/module.modulemap
@@ -1,0 +1,4 @@
+module date_time {
+    requires !cplusplus
+    export *
+}

--- a/Sources/describe/include/module.modulemap
+++ b/Sources/describe/include/module.modulemap
@@ -1,0 +1,4 @@
+module describe {
+    requires !cplusplus
+    export *
+}

--- a/Sources/detail/include/module.modulemap
+++ b/Sources/detail/include/module.modulemap
@@ -1,0 +1,4 @@
+module detail {
+    requires !cplusplus
+    export *
+}

--- a/Sources/foreach/include/module.modulemap
+++ b/Sources/foreach/include/module.modulemap
@@ -1,0 +1,4 @@
+module foreach {
+    requires !cplusplus
+    export *
+}

--- a/Sources/function/include/module.modulemap
+++ b/Sources/function/include/module.modulemap
@@ -1,0 +1,4 @@
+module function {
+    requires !cplusplus
+    export *
+}

--- a/Sources/integer/include/module.modulemap
+++ b/Sources/integer/include/module.modulemap
@@ -1,0 +1,4 @@
+module integer {
+    requires !cplusplus
+    export *
+}

--- a/Sources/io/include/module.modulemap
+++ b/Sources/io/include/module.modulemap
@@ -1,0 +1,4 @@
+module io {
+    requires !cplusplus
+    export *
+}

--- a/Sources/iterator/include/module.modulemap
+++ b/Sources/iterator/include/module.modulemap
@@ -1,0 +1,4 @@
+module iterator {
+    requires !cplusplus
+    export *
+}

--- a/Sources/lexical_cast/include/module.modulemap
+++ b/Sources/lexical_cast/include/module.modulemap
@@ -1,0 +1,4 @@
+module lexical_cast {
+    requires !cplusplus
+    export *
+}

--- a/Sources/move/include/module.modulemap
+++ b/Sources/move/include/module.modulemap
@@ -1,0 +1,4 @@
+module move {
+    requires !cplusplus
+    export *
+}

--- a/Sources/mp11/include/module.modulemap
+++ b/Sources/mp11/include/module.modulemap
@@ -1,0 +1,4 @@
+module mp11 {
+    requires !cplusplus
+    export *
+}

--- a/Sources/mpl/include/module.modulemap
+++ b/Sources/mpl/include/module.modulemap
@@ -1,0 +1,4 @@
+module mpl {
+    requires !cplusplus
+    export *
+}

--- a/Sources/multi_index/include/module.modulemap
+++ b/Sources/multi_index/include/module.modulemap
@@ -1,0 +1,4 @@
+module multi_index {
+    requires !cplusplus
+    export *
+}

--- a/Sources/numeric_conversion/include/module.modulemap
+++ b/Sources/numeric_conversion/include/module.modulemap
@@ -1,0 +1,4 @@
+module numeric_conversion {
+    requires !cplusplus
+    export *
+}

--- a/Sources/optional/include/module.modulemap
+++ b/Sources/optional/include/module.modulemap
@@ -1,0 +1,4 @@
+module optional {
+    requires !cplusplus
+    export *
+}

--- a/Sources/preprocessor/include/module.modulemap
+++ b/Sources/preprocessor/include/module.modulemap
@@ -1,0 +1,4 @@
+module preprocessor {
+    requires !cplusplus
+    export *
+}

--- a/Sources/range/include/module.modulemap
+++ b/Sources/range/include/module.modulemap
@@ -1,0 +1,4 @@
+module range {
+    requires !cplusplus
+    export *
+}

--- a/Sources/serialization/include/module.modulemap
+++ b/Sources/serialization/include/module.modulemap
@@ -1,0 +1,4 @@
+module serialization {
+    requires !cplusplus
+    export *
+}

--- a/Sources/signals2/include/module.modulemap
+++ b/Sources/signals2/include/module.modulemap
@@ -1,0 +1,4 @@
+module signals2 {
+    requires !cplusplus
+    export *
+}

--- a/Sources/smart_ptr/include/module.modulemap
+++ b/Sources/smart_ptr/include/module.modulemap
@@ -1,0 +1,4 @@
+module smart_ptr {
+    requires !cplusplus
+    export *
+}

--- a/Sources/static_assert/include/module.modulemap
+++ b/Sources/static_assert/include/module.modulemap
@@ -1,0 +1,4 @@
+module static_assert {
+    requires !cplusplus
+    export *
+}

--- a/Sources/throw_exception/include/module.modulemap
+++ b/Sources/throw_exception/include/module.modulemap
@@ -1,0 +1,4 @@
+module throw_exception {
+    requires !cplusplus
+    export *
+}

--- a/Sources/tokenizer/include/module.modulemap
+++ b/Sources/tokenizer/include/module.modulemap
@@ -1,0 +1,4 @@
+module tokenizer {
+    requires !cplusplus
+    export *
+}

--- a/Sources/tuple/include/module.modulemap
+++ b/Sources/tuple/include/module.modulemap
@@ -1,0 +1,4 @@
+module tuple {
+    requires !cplusplus
+    export *
+}

--- a/Sources/type_index/include/module.modulemap
+++ b/Sources/type_index/include/module.modulemap
@@ -1,0 +1,4 @@
+module type_index {
+    requires !cplusplus
+    export *
+}

--- a/Sources/type_traits/include/module.modulemap
+++ b/Sources/type_traits/include/module.modulemap
@@ -1,0 +1,4 @@
+module type_traits {
+    requires !cplusplus
+    export *
+}

--- a/Sources/utility/include/module.modulemap
+++ b/Sources/utility/include/module.modulemap
@@ -1,0 +1,4 @@
+module utility {
+    requires !cplusplus
+    export *
+}

--- a/Sources/variant/include/module.modulemap
+++ b/Sources/variant/include/module.modulemap
@@ -1,0 +1,4 @@
+module variant {
+    requires !cplusplus
+    export *
+}

--- a/subtree.yaml
+++ b/subtree.yaml
@@ -85,7 +85,7 @@ subtrees:
   remote: https://github.com/boostorg/date_time
   prefix: Vendor/date_time
   commit: 85e637cb325208c2af9af791c3a1948b4888c6cd
-  branch: boost-1.81.0
+  branch: boost-1.90.0
   squash: true
   extractions:
   - from: include/**/*.{hpp,h,ipp}


### PR DESCRIPTION
- Add GitHub Actions workflows for Apple platforms (macOS/iOS/visionOS) and Docker-based Linux builds
- Add Dockerfile for Linux verification (swift:6.3 image, builds + tests swift-boost, then builds LinuxConsumerProbe)
- Add .dockerignore to exclude build artifacts and .git from Docker context
- Add Examples/LinuxConsumerProbe: separate SPM package with four targets exercising external-consumer patterns